### PR TITLE
Strip trailing newline from classpath

### DIFF
--- a/resources/clj.py
+++ b/resources/clj.py
@@ -4,7 +4,7 @@ def main(*args):
     jars = javabridge.JARS
     classpath=os.getenv("CLASSPATH", None)
     if not classpath:
-        classpath = subprocess.check_output("clj -Spath", shell=True).decode('utf-8')
+        classpath = subprocess.check_output("clj -Spath", shell=True).decode('utf-8').strip()
 
     if classpath:
         jars = jars + [classpath]


### PR DESCRIPTION
In my environment I ended up with a trailing newline on the classpath and this had the unfortunate side effect of corrupting one of the names of the jars that clojure depends on.

The net effect was that `python3 clj.py` would not show a repl.

I guess this change actually operates on both the leading and trailing portions of the classpath string and applies to whitespace in general, not just newlines.

In any case, with the change applied, the repl now shows up.